### PR TITLE
SE-686 - LIKE operator for regexp values

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "version": "gulp compile && git add .",
     "test": "gulp compile && karma start && git checkout angular-sql-query.js angular-sql-query.min.js ",
     "cli": "env NPM_RUN_CLI=1",
-    "cover": "karma start karma.conf.js --single-run --reporters coverage",
+    "cover": "gulp compile && karma start karma.conf.js --single-run --reporters coverage",
     "codacy": "npm run cover && npm run codacy:send",
     "codacy:send": "cat ./coverage/report-lcov/lcov.info | ./node_modules/.bin/codacy-coverage",
     "coveralls": "npm run cover && npm run coveralls:send",

--- a/src/angular-sql-query.js
+++ b/src/angular-sql-query.js
@@ -565,6 +565,11 @@
   }
 
   /**
+   * @example
+   * // usage
+   * extractValues({} a: 1, b: [2, 3], c: /toto/ })
+   * // will return
+   * [1, 2, 3, '%toto%']
    * @param   {FiltersParameters} filtersParameters -
    * @returns {any[]}                               - Array of values
    */
@@ -572,7 +577,6 @@
     return Object.keys(filtersParameters)
       .map(key => filterValuesToSQLBindingsValues(filtersParameters[key]))
       .reduce((acc, value) => acc.concat(value), []); // flatten array values 
-    // extractValues({} a: 1, b: [2, 3], c: /toto/ }) => [1, 2, 3, '%toto%']
   }
 
   /**

--- a/src/angular-sql-query.spec.js
+++ b/src/angular-sql-query.spec.js
@@ -262,7 +262,7 @@
 
         function dbInstance() { return $q.when(sqlInstance); }
         backUp = new SqlQueryService('test', dbInstance, {
-          indexed_fields: ['test', 'test2'],
+          indexed_fields: ['test', 'test2', 'test3'],
         });
 
         executeStub.yields('test', backupDatas);
@@ -271,6 +271,7 @@
           test: 'test',
           isOk: true,
           test2: ['ok', 'not ok'],
+          test3: /partial/,
         }).then((_data_) => {
           data = _data_;
         });
@@ -278,8 +279,9 @@
         $timeout.flush();
 
         expect(executeStub.callCount).equal(1);
-        expect(executeStub.args[0][0]).equal('SELECT * FROM test WHERE test=? AND test2 IN (?,?);');
-        expect(executeStub.args[0][1]).deep.equal(['test', 'ok', 'not ok']);
+        expect(executeStub.args[0][0])
+          .equal('SELECT * FROM test WHERE test=? AND test2 IN (?,?) AND test3 LIKE ?;');
+        expect(executeStub.args[0][1]).deep.equal(['test', 'ok', 'not ok', '%partial%']);
 
         expect(data).lengthOf(1);
       }));


### PR DESCRIPTION
Detect if passed values are regexp
if yes use Like operator and extract regexp source in order to generate string 

Example: 

`filterparams = { name: /patr/ }`

will generate a where clause looking like 

`name LIKE ?`

bindings will be shaped like `['%patr%']`

